### PR TITLE
Find mcs on Fedora/RHEL systems

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-CSC=$(which mono-csc || which dmcs || echo "none")
+CSC=$(which mono-csc || which dmcs || which mcs || echo "none")
 
 if [ $CSC = "none" ]; then
 	echo "Error: Please install mono-devel."


### PR DESCRIPTION
This commit adds "which mcs" to detect mcs from mono-core on Fedora.
Tested against fedora 24 and f25.