### PR TITLE
Added a warning when the server accepts TLSv1.0

### DIFF
--- a/Src/Report.cs
+++ b/Src/Report.cs
@@ -472,6 +472,9 @@ class Report {
 		if (suites.ContainsKey(M.SSLv30)) {
 			warnings["PV003"] = "Server supports SSL 3.0.";
 		}
+		if (suites.ContainsKey(M.TLSv10)) {
+                        warnings["PV006"] = "Server supports TLS 1.0.";
+                }
 		if (unknownSKE) {
 			warnings["SK001"] = "Some Server Key Exchange messages"
 				+ " could not be processed.";


### PR DESCRIPTION
There are several issues with TLSv1.0 and it's being deprecated everywhere. The general consensus is that it should not be used anymore and similar tools issue warnings for this.

Reference: https://www.comodo.com/e-commerce/ssl-certificates/tls-1-deprecation.php

Best,

Leandro