### PR TITLE
Added a weak signature hashing algorithm warning for MD2, MD4, MD5 an…

### DIFF
--- a/Src/Report.cs
+++ b/Src/Report.cs
@@ -562,8 +562,17 @@ class Report {
 			foreach (string sh in shs) {
 				switch (sh) {
 				case "MD2":
+					hasBadSignHash = true;
+					break;
+				case "MD4":
+					hasBadSignHash = true;
+					break;
 				case "MD5":
+					hasBadSignHash = true;
+					break;
 				case "SHA-1":
+					hasBadSignHash = true;
+					break;
 				case "UNKNOWN":
 					hasBadSignHash = true;
 					break;


### PR DESCRIPTION
Adds a warning if any cert on the chain is using MD2, MD4, MD5 or SHA-1.

Reference: https://www.tenable.com/plugins/nessus/35291