### PR TITLE
Added a warning when a server supports TLSv1.0 or TLSv1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,21 @@ of some kind.
    support SSL 2.0, it merely claims to do so. Some other SSL scanning
    tools wrongly indicate this occurrence as "supports SSL 2.0", which
    is why this warning is included.
+   
+   - **PV006**
+
+   TLS 1.0 is deprecated as of March 2021. It has known flaws.
+   Recent clients and servers support TLS 1.2 and later and 
+   use a fallback mechanism to prevent attackers from forcing your 
+   brower to fallback to TLS 1.0. It is recomended to disable TLS 1.0 support.
+   
+   - **PV007**
+
+TLS 1.1 is deprecated as of March 2021. It has no known flaws
+but we don't want to take any risks. Recent clients and servers 
+support TLS 1.2 and later and use a fallback mechanism to 
+prevent attackers from forcing your browser back to fall back to TLS 1.1.
+It is recommended to disable TLS 1.1 spport.
 
  - **RN001**: Server does not support secure renegotiation.
 

--- a/Src/Report.cs
+++ b/Src/Report.cs
@@ -471,6 +471,12 @@ class Report {
 		}
 		if (suites.ContainsKey(M.SSLv30)) {
 			warnings["PV003"] = "Server supports SSL 3.0.";
+                }
+                if (suites.ContainsKey(M.TLSv10)) {
+                        warnings["PV006"] = "Server supports TLS 1.0.";
+                }
+                if (suites.ContainsKey(M.TLSv11)) {
+                        warnings["PV007"] = "Server supports TLS 1.1.";
 		}
 		if (unknownSKE) {
 			warnings["SK001"] = "Some Server Key Exchange messages"


### PR DESCRIPTION
TLS 1.0 has known flaws and is deprecated as of March 2021. TLS 1.1 has no known practical flaws but it is better not to take any risks. Chrome has already disabled TLS 1.0 and 1.1 support, and ssllabs gives a B to any site that supports TLS 1.0 or TLS 1.1. 